### PR TITLE
Use h2 for process block heading

### DIFF
--- a/src/components/process-block/process-block.js
+++ b/src/components/process-block/process-block.js
@@ -21,7 +21,7 @@ class ProcessBlock extends React.Component {
           <ul className={styles.processList}>
             {processes.map((process, index) => (
               <li key={`process-${index}`} className={styles.processItem}>
-                <h3 className={styles.processItemTitle}>{process.title}</h3>
+                <h2 className={styles.processItemTitle}>{process.title}</h2>
                 <p className={styles.processItemDesc}>{process.description}</p>
                 {process.pageLinkLabel && process.pageLink && 
                   <Link


### PR DESCRIPTION
This works for any page where the process block is displayed. It has no heading at a higher level, so makes sense to be h2. On pages where it was passing with an h3 it was just because there happened to be an unrelated h2 higher up the page.