### PR TITLE
200px space between logos and slider should only be there if there is…

### DIFF
--- a/src/components/quote-slider/quote-slider.module.scss
+++ b/src/components/quote-slider/quote-slider.module.scss
@@ -10,6 +10,7 @@ $testimonial-name: var(--testimonial-name);
         grid-template-columns: auto 1fr;
         grid-template-rows: auto auto;
         grid-column-gap: 50px;
+        margin-top: 200px;
     }
 
     &Icon {

--- a/src/components/testimonials-block/testimonials-block.module.scss
+++ b/src/components/testimonials-block/testimonials-block.module.scss
@@ -22,7 +22,6 @@
             display: flex;
             flex-wrap: wrap;
             flex-direction: row;
-            padding-bottom: 200px;
         }
 
         &Item {


### PR DESCRIPTION
… a testimonial below the logos

Easy fix here to move the spacing to the top of the quote slider. At some point we should refactor for the possible scenario if there are no logos, but Sophie is happy with this solution for launch.