### PR TITLE
Team page ordering fix

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,9 +8,14 @@ module.exports = {
     author: `@Torchbox`,
   },
   plugins: [
-    `gatsby-plugin-remove-trailing-slashes`,
+    `gatsby-plugin-force-trailing-slashes`,
     `gatsby-plugin-react-helmet`,
-    // 'gatsby-plugin-offline',
+    {
+      resolve: 'gatsby-plugin-offline',
+      options: {
+          navigateFallbackWhitelist: [/\/$/],
+      }
+    },
     {
       resolve: `gatsby-plugin-sass`,
       options: {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gatsby": "^2.0.98",
     "gatsby-image": "^2.0.20",
     "gatsby-plugin-compile-es6-packages": "^1.0.6",
+    "gatsby-plugin-force-trailing-slashes": "^1.0.4",
     "gatsby-plugin-manifest": "^2.0.9",
     "gatsby-plugin-offline": "^2.0.16",
     "gatsby-plugin-react-helmet": "^3.0.2",

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -132,22 +132,22 @@ class Layout extends React.Component {
   renderLinks = data => {
     return [
       {
-        href: 'digital-products',
+        href: '/digital-products/',
         title: 'Design + build products',
         strap: 'For digital design and engineering services',
       },
       {
-        href: 'wagtail-cms',
+        href: '/wagtail-cms/',
         title: 'Wagtail CMS services',
         strap: 'For web builds with the Wagtail open source CMS',
       },
       {
-        href: 'digital-marketing',
+        href: '/digital-marketing/',
         title: 'Digital marketing',
         strap: 'For our data driven digital marketing services',
       },
       {
-        href: 'culture-and-jobs',
+        href: '/culture-and-jobs/',
         title: 'Culture + jobs',
         strap: 'For our data driven digital marketing services',
         badge: safeGet(data, 'wagtail.jobsIndexPage.jobs.length', 0),

--- a/src/components/team-listing-block/team-listing-block.js
+++ b/src/components/team-listing-block/team-listing-block.js
@@ -10,13 +10,14 @@ const TeamListingBlock = ({ team, className }) => {
     <div className={[styles.block, className].join(' ')}>
       <div className={styles.blockContent}>
         <div className={styles.blockPersonList}>
-          {team.map((person, index) => (
+          {team.map((person) => (
             <Link
-              key={`person-link-${index}`}
+              key={person.key}
               className={styles.blockPersonLink}
               to={person.href}
             >
               <img
+                key={person.key}
                 className={styles.blockPersonLinkAvatar}
                 src={person.avatar}
                 alt={person.alt}

--- a/src/components/team-listing-block/team-listing-block.js
+++ b/src/components/team-listing-block/team-listing-block.js
@@ -17,7 +17,6 @@ const TeamListingBlock = ({ team, className }) => {
               to={person.href}
             >
               <img
-                key={person.key}
                 className={styles.blockPersonLinkAvatar}
                 src={person.avatar}
                 alt={person.alt}

--- a/src/templates/team/team-listing.js
+++ b/src/templates/team/team-listing.js
@@ -14,9 +14,18 @@ export class TeamListingPage extends React.Component {
   render() {
     const { title, team, contact, contactReasons } = this.props
 
-    const listing = team
+    /* 
+     * Quick hack to stop the list being rendered during static build as the React diffing algorithm is having
+     * issues replacing the static html (from Gatsby build) with dynamic html (from vanilla React) when this component
+     * is rebuilt in runtime. The diffing messes up the ordering so the images and text don't match. Need someone to look
+     * at this, my brain goes immeditetly to conflicting fiber node keys but that doesn't seem to be the case... _weird_ :/
+     */
+    let listing = []
+    if (typeof window != `undefined`) {
+      listing = listing.concat(team)
       .map(person => ({
-        name: person.firstName + ' ' + person.lastName,
+        key: `person-${person.firstName}-${person.lastName}`,
+        name:`${person.firstName} ${person.lastName}`,
         role: person.role,
         avatar: person.image.src.url,
         alt: person.image.alt,
@@ -24,6 +33,7 @@ export class TeamListingPage extends React.Component {
         isSenior: person.isSenior,
       }))
       .sort(person => (person.isSenior ? -1 : 1))
+    }
 
     return (
       <div className={styles.page}>

--- a/src/templates/team/team-listing.js
+++ b/src/templates/team/team-listing.js
@@ -23,16 +23,16 @@ export class TeamListingPage extends React.Component {
     let listing = []
     if (typeof window != `undefined`) {
       listing = listing.concat(team)
-      .map(person => ({
-        key: `person-${person.firstName}-${person.lastName}`,
-        name:`${person.firstName} ${person.lastName}`,
-        role: person.role,
-        avatar: person.image.src.url,
-        alt: person.image.alt,
-        href: teamUrl(person.slug),
-        isSenior: person.isSenior,
-      }))
-      .sort(person => (person.isSenior ? -1 : 1))
+        .map(person => ({
+          key: `person-${person.firstName}-${person.lastName}`,
+          name:`${person.firstName} ${person.lastName}`,
+          role: person.role,
+          avatar: person.image.src.url,
+          alt: person.image.alt,
+          href: teamUrl(person.slug),
+          isSenior: person.isSenior,
+        }))
+        .sort(person => (person.isSenior ? -1 : 1))
     }
 
     return (

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -1,22 +1,22 @@
-export const caseStudiesUrl = (slug = '') => `/work/${slug}`
+export const caseStudiesUrl = (slug = '') => `/work/${slug}/`
 export const caseStudiesFilterUrl = filter => {
   if (!filter) {
     return caseStudiesUrl()
   }
-  return `/work/#filter=${filter}`
+  return `/work/#filter=${filter}/`
 };
-export const blogsUrl = (slug = '') => `/blog/${slug}`
+export const blogsUrl = (slug = '') => `/blog/${slug}/`
 export const blogsFilterUrl = filter => {
   if (!filter) {
     return blogsUrl()
   }
-  return `/blog/#filter=${filter}`
+  return `/blog/#filter=${filter}/`
 };
-export const teamUrl = (slug = '') => `/team/${slug}`
-export const jobsUrl = (slug = '') => `/jobs/${slug}`
+export const teamUrl = (slug = '') => `/team/${slug}/`
+export const jobsUrl = (slug = '') => `/jobs/${slug}/`
 export const serviceUrl = (slug = '', parentServiceSlug = null) => {
   if (parentServiceSlug) {
-    return `${parentServiceSlug}/${slug}`
+    return `${parentServiceSlug}/${slug}/`
   } else {
     return slug
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,6 +916,14 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.51.tgz#48b8ed18307034c6620f643514650ca2ccc0165a"
+  integrity sha1-SLjtGDBwNMZiD2Q1FGUMoszAFlo=
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.11.1"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
@@ -6305,6 +6313,13 @@ gatsby-plugin-compile-es6-packages@^1.0.6:
     "@babel/runtime" "^7.0.0"
     regex-escape "^3.4.8"
 
+gatsby-plugin-force-trailing-slashes@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-force-trailing-slashes/-/gatsby-plugin-force-trailing-slashes-1.0.4.tgz#acbf1730aa63807a18a02960e96d4d6f98341df0"
+  integrity sha512-agzlGb1wou8lAMCfiLdKRgGCFrtsqMTANye3uUHbViHV1hPogh3MALlh5TzUMQLXTdlhRdoOtLedqCfLZF1/IQ==
+  dependencies:
+    "@babel/runtime" "7.0.0-beta.51"
+
 gatsby-plugin-manifest@^2.0.9:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.0.19.tgz#5f8bd5e18dec1f91e5a552faeab0eb4a63e213d2"
@@ -10791,7 +10806,7 @@ regenerator-runtime@^0.10.5:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
   integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==


### PR DESCRIPTION
### This PR solves two issues:

- The back button not working as expected on the team page. This was caused by the link URLs not having a leading slash, this caused the navigation buttons to bug out. I've fixed any hard-coded link URLs and installed a gatsby plugin to force leading slashes. This bug is fully fixed!

- The wrong ordering/element-mashup of the team members links. The current fix is a tempory one; I've stopped the gatsby server from compiling this image list during the build as the React diffing algorithm isn't replacing the elements correctly when the component is rerendered when the initial react application is bootstrapped in the browser runtime. This seems to be an issue with keys of list element nodes but not completely sure and wanted to get another memeber of the teams opinion. By gatsby building the list and delaying it till runtime means that the bug doesn't appear because the algorithm doesn't need to swap out the dom nodes from old static to new dynamic content. I've left a comment in `./src/layouts/team-listing:17` describing the issue aswell.