### PR TITLE
Fix search descriptions on sub service pages

### DIFF
--- a/src/templates/blog-post/index.js
+++ b/src/templates/blog-post/index.js
@@ -99,6 +99,14 @@ export const previewQuery = `
   query($slug: String, $previewToken: String) {
     blogPosts(slug: $slug, previewToken: $previewToken) {
       title
+      pageTitle
+      searchDescription
+      facebookImage: searchImage {
+        ...facebookImage
+      }
+      twitterImage: searchImage {
+        ...twitterImage
+      }
       date
       tags: relatedServices {
         name

--- a/src/templates/case-study/index.js
+++ b/src/templates/case-study/index.js
@@ -148,6 +148,12 @@ export const previewQuery = `
       title
       pageTitle
       searchDescription
+      facebookImage: searchImage {
+        ...facebookImage
+      }
+      twitterImage: searchImage {
+        ...twitterImage
+      }
       client
       feedImage {
         ...fullImage

--- a/src/templates/culture/index.js
+++ b/src/templates/culture/index.js
@@ -70,6 +70,7 @@ export const previewQuery = `
   query($previewToken: String) {
     culturePages(previewToken: $previewToken) {
       pageTitle
+      searchDescription
       slug
       strapline
       intro

--- a/src/templates/jobs/index.js
+++ b/src/templates/jobs/index.js
@@ -54,6 +54,7 @@ export const previewQuery = `
       title
       strapline
       pageTitle
+      searchDescription
 
       jobs {
         url

--- a/src/templates/person/index.js
+++ b/src/templates/person/index.js
@@ -90,6 +90,13 @@ export const previewQuery = `
   query($previewToken: String, $slug: String) {
     personPages(previewToken: $previewToken) {
       pageTitle
+      searchDescription
+      facebookImage: searchImage {
+        ...facebookImage
+      }
+      twitterImage: searchImage {
+        ...twitterImage
+      }
       firstName
       lastName
       role

--- a/src/templates/sub-service/index.js
+++ b/src/templates/sub-service/index.js
@@ -10,6 +10,7 @@ export const query = graphql`
       subServicePages(slug: $slug) {
         title
         pageTitle
+        searchDescription
         theme
         strapline
         intro
@@ -109,6 +110,7 @@ export const previewQuery = `
         subServicePages(previewToken: $previewToken) {
             title
             pageTitle
+            searchDescription
             theme
             strapline
             intro

--- a/src/templates/team/index.js
+++ b/src/templates/team/index.js
@@ -54,6 +54,7 @@ export const previewQuery = `
   query($previewToken: String) {
     personIndexPage(previewToken: $previewToken) {
       pageTitle
+      searchDescription
       strapline
     }
     personPages {


### PR DESCRIPTION
- Also ensures that the searchDescription is added to all the preview queries
- Also ensures that facebook image and twitter image are added to the preview queries where relevant