### PR TITLE
[203] Move offline config after manifest config (as per docs)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -18,12 +18,6 @@ module.exports = {
       }
     },
     {
-      resolve: 'gatsby-plugin-offline',
-      options: {
-          navigateFallbackWhitelist: [/\/$/],
-      }
-    },
-    {
       resolve: `gatsby-plugin-sass`,
       options: {
         includePaths: ['./src/fonts/'],
@@ -53,6 +47,12 @@ module.exports = {
         display: `minimal-ui`,
         icon: `src/images/favicon.png`, // This path is relative to the root of the site.
       },
+    },
+    {
+      resolve: 'gatsby-plugin-offline',
+      options: {
+          navigateFallbackWhitelist: [/\/$/],
+      }
     },
     {
       resolve: "gatsby-source-graphql",


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/tbxcom-redesign/tickets/203

Issue could be being caused by the the manifest plugin needing to be listed before the offline plugin.

https://www.gatsbyjs.org/docs/add-offline-support-with-a-service-worker/

> You can add a manifest file. Ensure that the manifest plugin is listed before the offline plugin so that the offline plugin can cache the created manifest.webmanifest.

