### PR TITLE
[209] Set default ligature on h1 headings

### DIFF
--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -4,6 +4,7 @@ h1 {
   font-size: 2em;
   line-height: 1.4em;
   font-weight: bold;
+  font-variant-ligatures: none;
 
   @include for-tablet-landscape-up {
     margin-right: 8.33vw;


### PR DESCRIPTION
https://projects.torchbox.com/projects/tbxcom-redesign/tickets/209

There are several heading one styles (that all look _similar_), so I opted for the most generic styling a oppose to setting the property on each variation individually.