### PR TITLE
222 Changing og:image tag from name to property

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -29,7 +29,7 @@ function SEO({ description, facebookImage, twitterImage, lang, meta, keywords, t
                 content: title,
               },
               {
-                name: `og:image`,
+                property: `og:image`,
                 content: facebookImage || defaultSearchImage,
               },
               {


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/tbxcom-redesign/tickets/222

Just debugging why social sharing image does not work on LinkedIn. All documentation seem to suggest `<meta property="og:image"` instead of `<meta name="og:image"`. Seems like a typo?