### PR TITLE
Redirect from netlify url to tbx custom domain

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,3 @@
 # /   /wagtail-cms            302!    Country=us
 /   /digital-products       302!
+https://tbx-production.netlify.app/* https://torchbox.com/:splat 301!


### PR DESCRIPTION
This PR adds a manual redirect to the Netlify configuration file so that requests are forced to our custom torchbox.com domain as opposed to https://tbx-production.netlify.app/

This should also stop google indexing it... This change was suggested in ticket #283 from this [link](https://community.netlify.com/t/delete-default-subdomain/14573)