### PR TITLE
Cookie Banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11438,6 +11438,11 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
       "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -14325,6 +14330,14 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.6"
+      }
+    },
+    "react-cookie-consent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-cookie-consent/-/react-cookie-consent-5.1.2.tgz",
+      "integrity": "sha512-FsTLsypqJpg2VjBa6nMT0jNMrk+4C/TUQkRm6mtDFnR6HNPrzMCWi3OHRXVptyL4h8ZbJLk74qZcL0VDUS1+cQ==",
+      "requires": {
+        "js-cookie": "^2.2.1"
       }
     },
     "react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "prop-types": "^15.6.2",
     "query-string": "^6.2.0",
     "react": "^16.8.2",
+    "react-cookie-consent": "^5.1.2",
     "react-dom": "^16.6.3",
     "react-helmet": "^5.2.0",
     "react-markdown": "^4.0.8",

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -81,10 +81,10 @@ class Layout extends React.Component {
                 cookieName="cookie-consent"
                 enableDeclineButton={true}
                 style={{ background: 'var(--color-blue)' }}
-                buttonStyle={{ backgroundColor: '#fd5765', color: 'white', fontSize: '16px' }}
+                buttonStyle={{ backgroundColor: 'var(--color-coral)', color: 'white', fontSize: '16px' }}
                 declineButtonStyle={{ backgroundColor: 'transparent', color: 'white', fontSize: '16px', marginRight: '0' }}
               >
-                  We use cookies to measure how you use the website. We want our site to be easy for you to use; understanding how you interact with it helps us know that. <Link style={{ color: 'white', borderBottom: '2px solid #fd5765' }} to="/cookies">Find out more</Link>.
+                  We use cookies to measure how you use the website. We want our site to be easy for you to use; understanding how you interact with it helps us know that. <Link style={{ color: 'white', borderBottom: '2px solid var(--color-blue)' }} to="/cookies">Find out more</Link>.
               </CookieConsent>
               <Header
                 title={title}

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -1,7 +1,7 @@
 // Vendor Modules
 import React from 'react'
 import PropTypes from 'prop-types'
-import { StaticQuery, graphql } from 'gatsby'
+import { StaticQuery, graphql, Link } from 'gatsby'
 import cssVars from 'css-vars-ponyfill'
 import scrollIntoView from 'scroll-into-view';
 import CookieConsent from 'react-cookie-consent';
@@ -76,17 +76,15 @@ class Layout extends React.Component {
             <ThemeProvider theme={theme}>
               <CookieConsent
                 location="bottom"
-                buttonText={<div>&#10005;</div>}
+                buttonText="Opt-in"
                 declineButtonText="Opt-out"
                 cookieName="cookie-consent"
-                cookieValue={true}
-                declineCookieValue={false}
                 enableDeclineButton={true}
                 style={{ background: 'var(--color-blue)' }}
-                buttonStyle={{ background: 'transparent', color: 'white', padding: '5px 10px', margin: '0 10px 0 0', fontSize: '30px', position: 'relative', top: '5px' }}
-                declineButtonStyle={{ backgroundColor: 'var(--color-accent)', color: 'white', fontSize: '16px' }}
+                buttonStyle={{ backgroundColor: '#fd5765', color: 'white', fontSize: '16px' }}
+                declineButtonStyle={{ backgroundColor: 'transparent', color: 'white', fontSize: '16px', marginRight: '0' }}
               >
-                  We use cookies to provide you with a better service. Close this banner if you&apos;re happy with this, or <a style={{color: 'white'}} href="#">find out more</a>.
+                  We use cookies to provide you with a better service. Carry on browsing if you&apos;re happy with this, or <Link style={{ color: 'white', borderBottom: '2px solid #fd5765' }} to="/cookies">find out more</Link>.
               </CookieConsent>
               <Header
                 title={title}

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -80,7 +80,7 @@ class Layout extends React.Component {
                 declineButtonText="Opt-out"
                 cookieName="cookie-consent"
                 enableDeclineButton={true}
-                style={{ background: 'var(--color-blue)' }}
+                style={{ background: 'var(--color-blue)', borderTop: '1px solid white' }}
                 buttonStyle={{ backgroundColor: 'var(--color-coral)', color: 'white', fontSize: '16px' }}
                 declineButtonStyle={{ backgroundColor: 'transparent', color: 'white', fontSize: '16px', marginRight: '0' }}
               >

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { StaticQuery, graphql } from 'gatsby'
 import cssVars from 'css-vars-ponyfill'
 import scrollIntoView from 'scroll-into-view';
+import CookieConsent from 'react-cookie-consent';
 // Components
 import Header from '@components/header'
 import Footer from '@components/footer'
@@ -73,6 +74,20 @@ class Layout extends React.Component {
               twitterImage={safeGet(twitterImage, 'src.url', null)}
             />
             <ThemeProvider theme={theme}>
+              <CookieConsent
+                location="bottom"
+                buttonText={<div>&#10005;</div>}
+                declineButtonText="Opt-out"
+                cookieName="cookie-consent"
+                cookieValue={true}
+                declineCookieValue={false}
+                enableDeclineButton={true}
+                style={{ background: 'var(--color-blue)' }}
+                buttonStyle={{ background: 'transparent', color: 'white', padding: '5px 10px', margin: '0 10px 0 0', fontSize: '30px', position: 'relative', top: '5px' }}
+                declineButtonStyle={{ backgroundColor: 'var(--color-accent)', color: 'white', fontSize: '16px' }}
+              >
+                  We use cookies to provide you with a better service. Close this banner if you&apos;re happy with this, or <a style={{color: 'white'}} href="#">find out more</a>.
+              </CookieConsent>
               <Header
                 title={title}
                 currentUrl={this.state.currentUrl}

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -84,7 +84,7 @@ class Layout extends React.Component {
                 buttonStyle={{ backgroundColor: '#fd5765', color: 'white', fontSize: '16px' }}
                 declineButtonStyle={{ backgroundColor: 'transparent', color: 'white', fontSize: '16px', marginRight: '0' }}
               >
-                  We use cookies to provide you with a better service. Carry on browsing if you&apos;re happy with this, or <Link style={{ color: 'white', borderBottom: '2px solid #fd5765' }} to="/cookies">find out more</Link>.
+                  We use cookies to measure how you use the website. We want our site to be easy for you to use; understanding how you interact with it helps us know that. <Link style={{ color: 'white', borderBottom: '2px solid #fd5765' }} to="/cookies">Find out more</Link>.
               </CookieConsent>
               <Header
                 title={title}

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -84,7 +84,7 @@ class Layout extends React.Component {
                 buttonStyle={{ backgroundColor: 'var(--color-coral)', color: 'white', fontSize: '16px' }}
                 declineButtonStyle={{ backgroundColor: 'transparent', color: 'white', fontSize: '16px', marginRight: '0' }}
               >
-                  We use cookies to measure how you use the website. We want our site to be easy for you to use; understanding how you interact with it helps us know that. <Link style={{ color: 'white', borderBottom: '2px solid var(--color-blue)' }} to="/cookies">Find out more</Link>.
+                  We use cookies to measure how you use the website. We want our site to be easy for you to use; understanding how you interact with it helps us know that. <Link style={{ color: 'white', borderBottom: '2px solid var(--color-coral)' }} to="/cookies">Find out more</Link>.
               </CookieConsent>
               <Header
                 title={title}


### PR DESCRIPTION
Adds a cookie banner via [React Cookie Consent](https://www.npmjs.com/package/react-cookie-consent)

Sets a cookie called `cookie-consent` to `true` if the user opts-in and `false` if they opt out. This will then be read by GTM and used to track or not track.