### PR TITLE
Fix aligned image fragment

### DIFF
--- a/src/components/streamfield-block/streamfield-block.js
+++ b/src/components/streamfield-block/streamfield-block.js
@@ -29,6 +29,13 @@ class StreamfieldBlock extends React.Component {
 
             case 'aligned_image':
               const aligned_image = React.createRef()
+              const aligmentClass = {
+                'half': styles.streamfieldAlignedImageHalfWidth,
+                'full': styles.streamfieldAlignedImageFullWidth,
+                'left': styles.streamfieldAlignedImageWrapLeft,
+                'right': styles.streamfieldAlignedImageWrapRight,
+              }[block.value?.alignment ?? "full"]
+
               return (
                 <div
                   className={styles.streamfieldAlignedImage}
@@ -38,12 +45,16 @@ class StreamfieldBlock extends React.Component {
                     ref={aligned_image}
                     src={block.value.image.src}
                     alt={block.value.image.alt || ""}
-                    className={styles.streamfieldAlignedImageImg}
+                    className={aligmentClass}
                     onError={() => {
                       aligned_image.current.src = require('@images/default-featured.png')
                     }}
                   />
-                  <div className={styles.streamfieldAlignedImageCaption}>
+                  <div className={
+                    block.value.alignment == "right"
+                      ? styles.streamfieldAlignedImageCaptionRight
+                      : styles.streamfieldAlignedImageCaption
+                  }>
                     <p>{block.value.caption}</p>
                   </div>
                 </div>

--- a/src/components/streamfield-block/streamfield-block.module.scss
+++ b/src/components/streamfield-block/streamfield-block.module.scss
@@ -124,8 +124,22 @@
     height: auto;
     margin: 60px 0 60px;
 
-    &Img {
+    &FullWidth {
       width: 100%;
+    }
+
+    &HalfWidth {
+      width: 50%;
+    }
+
+    &WrapLeft {
+      max-width: 100%;
+    }
+
+    &WrapRight {
+      display: block;
+      max-width: 100%;
+      margin-left: auto;
     }
 
     &Caption {
@@ -135,6 +149,11 @@
         color: rgba(51, 51, 51, 0.7);
         margin-bottom: 0;
       }
+    }
+
+    &CaptionRight {
+      @extend .streamfieldAlignedImageCaption;
+      text-align: right;
     }
   }
 


### PR DESCRIPTION
This PR fixes the aligned image fragment. For the following Wagtail values it has the proceeding output:

`full`:
<img width="1309" alt="Screenshot 2020-07-21 at 10 34 25" src="https://user-images.githubusercontent.com/13197111/88038157-c2363f00-cb3d-11ea-8448-554e8a7be941.png">

`half`:
<img width="1403" alt="Screenshot 2020-07-21 at 10 33 22" src="https://user-images.githubusercontent.com/13197111/88038051-9d41cc00-cb3d-11ea-8369-c3591e889667.png">

`left`:
<img width="1552" alt="Screenshot 2020-07-21 at 10 32 52" src="https://user-images.githubusercontent.com/13197111/88037998-8a2efc00-cb3d-11ea-8d83-da52cdef3c16.png">

`right`:
<img width="1401" alt="Screenshot 2020-07-21 at 10 32 04" src="https://user-images.githubusercontent.com/13197111/88037924-6e2b5a80-cb3d-11ea-9b66-7dc878fbaba4.png">
