### PR TITLE
Add missing into field to JobsIndexPage preview query

### DIFF
--- a/src/templates/jobs/index.js
+++ b/src/templates/jobs/index.js
@@ -28,10 +28,10 @@ export const query = graphql`
     wagtail {
       jobsIndexPage {
         title
+        intro
         strapline
         pageTitle
         searchDescription
-        intro
 
         jobs {
           id
@@ -56,6 +56,7 @@ export const previewQuery = `
   query($previewToken: String) {
     jobsIndexPage(previewToken: $previewToken) {
       title
+      intro
       strapline
       pageTitle
       searchDescription


### PR DESCRIPTION
When previewing the intro shows as `undefined` because If robot tot add into to the preview query.